### PR TITLE
Update AramFeuilleRouge.md

### DIFF
--- a/Bestiaire/Anathazerin/03 - Le Sanctuaire/AramFeuilleRouge.md
+++ b/Bestiaire/Anathazerin/03 - Le Sanctuaire/AramFeuilleRouge.md
@@ -2,7 +2,7 @@
 # Aram Feuille Rouge
 
 Allure : 6
-Charisme : -2 (effacé)
+
 
 	Agi	Âme	For	Int	Vig
 	d10	d8	d6	d6	d6


### PR DESCRIPTION
effacé le charisme -2, car marqué effacé. Vu le manque de Handicap, et la charisme initial -(-1) ça me semblait logique