### PR TITLE
Update Durub.md

### DIFF
--- a/Bestiaire/Anathazerin/01 - Retour a Clairval/Durub.md
+++ b/Bestiaire/Anathazerin/01 - Retour a Clairval/Durub.md
@@ -12,8 +12,8 @@ Compétences : Combat d6, Discrétion d10, Escalade d6, Lancer d4, Magie d8,
 
 ### Capacités spéciales
 - Arcanes : Magie d8, PP15.
-- Infravision : divise de moitié les malus (arrondir à l’inférieur) aux attaques pour luminosité faible.
-- Taille -1 : un gobelin mesure entre 1m et 1m20.
+- Infravision : divise de moitié les malus (arrondir à l’inférieur) pour luminosité faible.
+- Taille -1 : mesure entre 1m et 1m20.
 
 ### Actions
 - Dague : Combat d6, 2d4.
@@ -21,5 +21,5 @@ Compétences : Combat d6, Discrétion d10, Escalade d6, Lancer d4, Magie d8,
 - _Eclair_ : Magie d8, PP1-3, 12/24/48, Inst.
 
 ### Equipement
-Dague, Elixir de guérison, Poison (-2).
+Dague, Élixir de guérison, Poison (-2).
 

--- a/Bestiaire/Anathazerin/01 - Retour a Clairval/Durub.md
+++ b/Bestiaire/Anathazerin/01 - Retour a Clairval/Durub.md
@@ -5,14 +5,14 @@ Allure : 6
 	Agi	Âme	For	Int	Vig
 	d8	d8	d4	d6	d6
 
-Compétences : Combat d6, Discrétion d10, Escalade d6, Lancer d4, Magie d8, Natation d6, Perception d8, Sarcasmes d6, Tir d4
+Compétences : Combat d6, Discrétion d10, Escalade d6, Lancer d4, Magie d8, Natation d6, Perception d8, Sarcasmes d6, Tir d4.
 
 	PAR	RES
 	5	4
 
 ### Capacités spéciales
 - Arcanes : Magie d8, PP15.
-- Infravision : divise de moitié les malus (arrondir à l’inférieur) pour luminosité faible.
+- Infravision : réduit de moitié les malus (arrondir à l’inférieur) pour luminosité faible.
 - Taille -1 : mesure entre 1m et 1m20.
 
 ### Actions


### PR DESCRIPTION
Infravision : pourquoi limiter aux attaques ? N'est ce pas aussi le cas des tests de Perception ou ceux d'Agilité pour esquiver une attaque de zone pour laquelle le meneur jugerait les malus d'obscurité applicables ?