### PR TITLE
Update AndraMortemire.md

### DIFF
--- a/Bestiaire/Anathazerin/02 - Fort Boueux/AndraMortemire.md
+++ b/Bestiaire/Anathazerin/02 - Fort Boueux/AndraMortemire.md
@@ -15,10 +15,10 @@ Compétences : Combat d8, Connaissance (Religion) d6, Foi d10, Perception d6, S
 
 ### Actions
 - Epée courte : Combat d8, 2d6.
-- Guerrier saint : peut repousser les morts-vivants et les démons pour 1PP en cas d’échec de ces derniers sur un jet d’Âme, où les détruire (ou leur infliger une Blessure pour les Jokers) en cas de 1 sur leur jet.
+- Guerrier saint : peut repousser les morts-vivants et les démons pour 1PP. Ceux-ci résistent avec Succès sur un jet d'Âme, sont repoussés sur Échec et subissent une Blessure en cas de 1 au jet.
 - _Frappe_ : Foi d10, PP2, T, 3(1/rd).
 - _Guérison_ : Foi d10, PP3, T, Inst.
 - _Secours_ : Foi d10, PP1, T, Inst.
 
 ### Equipement
-Armure de cuir (+1), épée courte (For+d6)
+Armure de cuir, épée courte.

--- a/Bestiaire/Anathazerin/02 - Fort Boueux/AndraMortemire.md
+++ b/Bestiaire/Anathazerin/02 - Fort Boueux/AndraMortemire.md
@@ -20,5 +20,5 @@ Compétences : Combat d8, Connaissance (Religion) d6, Foi d10, Perception d6, S
 - _Guérison_ : Foi d10, PP3, T, Inst.
 - _Secours_ : Foi d10, PP1, T, Inst.
 
-### Equipement
+### Équipement
 Armure de cuir, épée courte.


### PR DESCRIPTION
Guerrier saint : phrase éclatée en plusieurs pour une compréhension plus aisée.
Si l'ancienne version est conservée, il faut corriger "où" en "ou"