### PR TITLE
Update AramFeuilleRouge.md

### DIFF
--- a/Bestiaire/Anathazerin/03 - Le Sanctuaire/AramFeuilleRouge.md
+++ b/Bestiaire/Anathazerin/03 - Le Sanctuaire/AramFeuilleRouge.md
@@ -5,7 +5,7 @@ Allure : 6
 
 
 	Agi	Âme	For	Int	Vig
-	d10	d8	d6	d6	d6
+	d10	d8	d8	d6	d6
 
 Compétences : Combat d6, Discrétion d6+2, Équitation d4, Perception d8, Tir d10.
 
@@ -20,8 +20,8 @@ Atouts : Forestier, Tireur d'élite, Vigilance.
 
 ### Actions
 - Tireur d'élite : la manoeuvre Visée (+2 en Tir) est automatique si le personnage ne se déplace pas.
-- Épée courte : Combat d6, 2d6.
-- Arc long : Tir d10-1, 15/30/60, 2d6.
+- Épée courte : Combat d6, d8+d6.
+- Arc long : Tir d10, 15/30/60, 2d6.
 
 ### Équipement
 Armure de cuir, épée courte, Arc long.

--- a/Bestiaire/Anathazerin/03 - Le Sanctuaire/AramFeuilleRouge.md
+++ b/Bestiaire/Anathazerin/03 - Le Sanctuaire/AramFeuilleRouge.md
@@ -12,16 +12,16 @@ Compétences : Combat d6, Discrétion d6+2, Équitation d4, Perception d8, Tir 
 Atouts : Forestier, Tireur d'élite, Vigilance.
 
 	PAR	RES
-	5   6 (1)
+	5       6 (1)
 
 ### Capacités spéciales
-- Commandement : Les troupes ont un bonus de +1 pour récupérer d’un état Secoué.
-- Ferveur : Les troupes ont un bonus de +1 aux dégâts.
+- Commandement : +1 pour récupérer d’un état Secoué pour les alliés dans un rayon de 5 cases.
+- Ferveur : +1 aux dégâts pour les alliés dans un rayon de 5 cases.
 
 ### Actions
-- Tireur d'élite : La manoeuvre Visée (+2 en Tir) est automatique si le personnage ne se déplace pas.
+- Tireur d'élite : la manoeuvre Visée (+2 en Tir) est automatique si le personnage ne se déplace pas.
 - Épée courte : Combat d6, 2d6.
-- Arc long : Tir d10, 15/30/60, 2d6
+- Arc long : Tir d10-1, 15/30/60, 2d6.
 
-### Equipement
-Armure de cuir (+1), épée courte, Arc long.
+### Équipement
+Armure de cuir, épée courte, Arc long.


### PR DESCRIPTION
Ne dispose pas de la force requise pour un arc long (d8) et subit -1 au tir. Laisser en l'état, changer pour un arc court ou augmenter la force à d8.