### PR TITLE
Update Urgashn.md

### DIFF
--- a/Bestiaire/Anathazerin/03 - Le Sanctuaire/Urgashn.md
+++ b/Bestiaire/Anathazerin/03 - Le Sanctuaire/Urgashn.md
@@ -16,7 +16,7 @@ Compétences : Combat d12, Discrétion d6, Intimidation d10, Lancer d8, Percepti
 - Vampirisation : Âme d8, portée 6, ignore l'armure, 2d6. Chaque fois que cette attaque inflige une ou plusieurs Blessures, Urgashn peut se soigner d'une Blessure.
 
 ### Réactions
-- Vampirisation : chaque fois qu’une créature meurt dans un rayon de 8 cases, Urgashn peut se soigner d'une Blessure.
+- Vampirisation : chaque fois qu'une créature dans un rayon de 8 cases devient Incapacitée suite à une Blessure (et non un cumul de Secoué), Urgashn peut se soigner d'une Blessure
 
 ### Équipement
 Armure de cuir, hache à deux mains en Durium, Baguette de défoliation (12 charges, 3d6 dégâts aux créatures végétales, tue la végétation non magique sur 50m de rayon), trois améthystes de 100 pa chacune, 30 po et 153 pa.

--- a/Bestiaire/Anathazerin/03 - Le Sanctuaire/Urgashn.md
+++ b/Bestiaire/Anathazerin/03 - Le Sanctuaire/Urgashn.md
@@ -12,11 +12,11 @@ Compétences : Combat d12, Discrétion d6, Intimidation d10, Lancer d8, Percepti
 
 ### Actions
 - Hache à deux mains : Combat d12, Parade -1, PA2, 2d10.
-- Taille +1 : les orques sont un peu plus grands que les humains.
+- Taille +1 : un peu plus grands qu'un humain.
 - Vampirisation : Âme d8, portée 6, ignore l'armure, 2d6. Chaque fois que cette attaque inflige une ou plusieurs Blessures, Urgashn peut se soigner d'une Blessure.
 
 ### Réactions
 - Vampirisation : chaque fois qu’une créature meurt dans un rayon de 8 cases, Urgashn peut se soigner d'une Blessure.
 
 ### Équipement
-Armure de cuir (+1), hache à deux mains en Durium (Parade -1, PA2, For+d10), Baguette de défoliation (12 charges, 3d6 dégâts aux créatures végétales, tue la végétation non magique sur 50m de rayon), trois améthystes de 100 pa chacune, 30 po et 153 pa.
+Armure de cuir, hache à deux mains en Durium, Baguette de défoliation (12 charges, 3d6 dégâts aux créatures végétales, tue la végétation non magique sur 50m de rayon), trois améthystes de 100 pa chacune, 30 po et 153 pa.


### PR DESCRIPTION
Note sur vampirisation (réaction) : un Extra est mis hors combat, il n'est pas forcément tué. C'est après la bataille qu'il y a si besoin un jet de Vigueur pour statuer. Donc soit il faut faire le jet de Vigueur au moment où l'Extra est mis hors combat ou twister un peu la règle genre : "chaque fois qu'une créature dans un rayon de 8 cases devient Incapacité suite à une Blessure (et non un cumul de Secoué), Urgashn peut se soigner d'une Blessure".