### PR TITLE
Update AtoutsEtCapacites.md

### DIFF
--- a/Bestiaire/AtoutsEtCapacites.md
+++ b/Bestiaire/AtoutsEtCapacites.md
@@ -15,10 +15,10 @@
 - Expert en bouclier : annule le malus d'Arme improvisée, dégâts For+d4/d4/d6 (petit/moyen/grand) y compris pour Repousser.
 - Extraction : en cas de retraite, évite 1 attaque gratuite sur Succès d’Agilité.
 - Ferveur : dégâts +1 pour les alliés dans un rayon de 5 cases.
+- Florentine : Combat +1 contre cible avec une arme et sans bouclier. Annule 1 point de bonus d'attaquants multiples.
 - Fracassement : PA +1 pour Combat, +2 sur Relance.
 - Frappe éclair : attaque gratuite par Round sur un ennemi arrivant au contact.
 - Frappe foudroyante : attaque gratuite sur chaque ennemi arrivant au contact.
-- Florentine : Combat +1 contre cible avec une arme et sans bouclier. Annule 1 point de bonus d'attaquants multiples.
 - Frénésie : peut faire une attaque en Combat supplémentaire, -2 à toutes les attaques du Round.
 - Frénésie suprême : peut faire une attaque en Combat supplémentaire.
 - Grand balayage : attaque toute cible adjacente.
@@ -26,21 +26,20 @@
 - Grand fracassement : PA +2 pour Combat, +4 sur Relance.
 - Grande extraction : en cas de retraite, évite 1 attaque gratuite sur Succès d'Agilité, toutes sur Relance.
 - Grande résistance aux arcanes : Armure +4 contre la magie, +4 pour résister aux Pouvoirs.
-- Guerrier impie : peut repousser les créatures angéliques, paladins ou personnages du bien ayant l’Atout Arcanes (Miracles) pour 1PP. Repoussé sur Échec en Âme, +1 Blessure sur 1 au jet.
-- Guerrier saint : peut repousser les morts-vivants et les démons pour 1PP. Repoussé sur Échec en Âme, +1 Blessure sur 1 au jet.
+- Guerrier impie : peut repousser les créatures angéliques, paladins ou personnages du Bien ayant l’Atout Arcanes (Miracles) pour 1PP. Repoussé sur Échec d'Âme, +1 Blessure sur 1 au jet.
+- Guerrier saint : peut repousser les morts-vivants et les démons pour 1PP. Repoussé sur Échec d'Âme, +1 Blessure sur 1 au jet.
 - Inspiration : +2 pour annuler Secoué pour les alliés dans un rayon de 5 cases (Commandement inclus).
 - Leader naturel : peut donner des Jetons aux alliés dans un rayon de 5 cases.
 - Nerfs d’acier : annule 1 point de malus de Blessures.
 - Panache : Trait +2 en dépensant un Jeton, Encaissement inclus.
 - Résistance aux arcanes : Armure +2 contre la magie, +2 pour résister aux Pouvoirs.
-- Résistant : pas de Blessure si Secoué deux fois.
 - Sans pitié : peut utiliser des Jetons sur les jets de dégâts.
-- Tacticien : reçoit en début de combat une carte d'Initiative par Succès et Relance en Connaissance (Bataille) pouvant remplacer durant le combat une carte d’Initiative pour les alliés dans un rayon de 5 cases.
+- Tacticien : reçoit en début de combat une carte d'Initiative par Succès et Relance de Connaissance (Bataille) pouvant remplacer durant le combat une carte d’Initiative pour les alliés dans un rayon de 5 cases.
 - Tête froide : agit sur la meilleure de deux cartes d’Initiative.
 - Tireur d'élite : Tir +2 si pas de mouvement (Visée).
 - Tueur d'orques : dégâts +d6 contre les orques.
 - Tueur de géants : dégâts +d6 contre les grandes créatures (Taille +3).
-- Vif : Défausse les cartes d'Initiative de 5 ou moins.
+- Vif : défausse les cartes d'Initiative de 5 ou moins.
 - Volonté de fer : Intimidation +2, Sarcasme +2, y résister +2.
 
 _Remarque : si Grande aura de commandement, passer les rayon des Atouts de commandement de 5 à 10 cases._
@@ -50,7 +49,7 @@ _Remarque : si Grande aura de commandement, passer les rayon des Atouts de comma
 - À la gorge : touche la zone la moins protégée sur Relance en attaque.
 - Aura enflammée : inflige en fin d'action 2d6 dégâts de Feu à toute créature adjacente.
 - Aura glaciale : inflige en fin d'action 2d6 dégâts de Froid à toute créature adjacente.
-- Créature artificielle : +2 pour annuler Secoué. Immunisé aux Attaques ciblées, aux maladies et aux poisons. Ignore les malus de Blessures.
+- Créature artificielle : +2 pour annuler Secoué. Immunisé aux Attaques ciblées, aux maladies et aux poisons. Annule les malus de Blessures.
 - Démon : +2 pour annuler Secoué. Immunisé aux poisons et maladies.
 - Élémentaire : Immunisé aux attaques ciblées, la Terreur, l'Intimidation, les maladies et les poisons.
 - Enfouissement : peut se déplacer sous terre. Peut surprendre sa cible : Combat +2/+4 et dégâts +2/+4 sur Succès/Relance de Discrétion contre Perception.
@@ -63,11 +62,12 @@ _Remarque : si Grande aura de commandement, passer les rayon des Atouts de comma
 - Infravision : réduit de moitié les malus pour manque d'éclairage (arrondir à l'inférieur).
 - Immatériel : immunisé aux attaques non magiques.
 - Invulnérabilté : peut être Secoué mais pas Blessé sauf Point faible.
-- Mort-vivant : Résistance +2. +2 pour annuler Secoué. Immunisé aux attaques ciblées, aux maladies et aux poisons. Ignore les malus de Blessures.
+- Mort-vivant : Résistance +2. +2 pour annuler Secoué. Immunisé aux attaques ciblées, aux maladies et aux poisons. Annule les malus de Blessures.
 - Petit : attaque adverse -2 si en mouvement.
-- Plante : +2 pour annuler Secoué. Immunisé aux Attaques ciblées et aux poisons. Ignore les malus de Blessures.
+- Plante : +2 pour annuler Secoué. Immunisé aux Attaques ciblées et aux poisons. Annule les malus de Blessures.
 - Régénération rapide : +2 pour annuler Secoué. Guérison naturelle chaque Round. Ne fonctionne pas pour les Blessures de feu.
 _Remarque : la régénération rapide de l'hydre est spécifique._
+- Résistant : pas de Blessure si Secoué deux fois.
 - Sans peur : immunisé à la Terreur et l'Intimidation.
 - Taille [+-]X.
-- Toucher glacial (-X) : Combat dX+2, +1 Fatigue sur Échec en Vigueur -X, peut provoquer l'Etat Critique puis la transformation en XXX, récupère 1 Fatigue/12h- Vision nocturne : ignore les malus de Pénombre et d'Obscurité.
+- Toucher glacial (-X) : Combat dX+2, +1 Fatigue sur Échec en Vigueur -X, peut provoquer l'Etat Critique puis la transformation en XXX, récupère 1 Fatigue/12h- Vision nocturne : annule les malus de Pénombre et d'Obscurité.


### PR DESCRIPTION
respect de la syntaxe {Résultat} de Trait.
Florentine reclassé dans ordre alphabétique.
Résistant va dans les Capacités, pas dans les Atouts
Un coup on annule des malus, un coup on les ignore --> utilisation systématique d'annuler.